### PR TITLE
static-geckoengage-webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
                             </ul>
                         </li>
                         <li>Paste the code above into the console and press Enter</li>
-                        <li>The chat widget will appear on the page, ready for demonstration</li>
+                        <li>After a few seconds, the chat widget will appear on the page, ready for demonstration.</li>
                     </ol>
                 </div>
             </div>
@@ -571,8 +571,8 @@ document.head.appendChild(script);`;
                 return;
             }
             
-            // Generate URL
-            const baseUrl = window.location.href.split('?')[0];
+            // Generate URL with fixed base URL
+            const baseUrl = "https://geckoengage.com/assets/widget-test.html";
             const fullUrl = `${baseUrl}?widgetId=${params.widgetId}&accountName=${params.accountName}`;
             
             // Display URL
@@ -591,7 +591,7 @@ document.head.appendChild(script);`;
                     console.error('Could not copy text: ', err);
                 });
         }
-        
+            
         // Function to copy embed code
         function copyEmbedCode() {
             const embedCode = document.getElementById('embed-code').textContent;


### PR DESCRIPTION
Now uses a static geckoengage webpage for testing instead of a github link. thanks to Brian!